### PR TITLE
feat: add migration to add invite_code column to lobbies table

### DIFF
--- a/src/prisma/migrations/20221020142602_add_lobby_invite_code/migration.sql
+++ b/src/prisma/migrations/20221020142602_add_lobby_invite_code/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `invite_code` to the `Lobby` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Lobby" ADD COLUMN     "invite_code" TEXT NOT NULL;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Lobby {
   owner_id        Int
   tournament_id   Int
   password        String
+  invite_code     String
   owner           User        @relation(fields: [owner_id], references: [id])
   user_lobbies    UserLobby[]
 }


### PR DESCRIPTION
add an invite code to a lobby to avoid users randomly entering other lobbies