### PR TITLE
feature: remove password field from lobbies table

### DIFF
--- a/src/prisma/migrations/20221020143138_remove_lobby_password/migration.sql
+++ b/src/prisma/migrations/20221020143138_remove_lobby_password/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `password` on the `Lobby` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Lobby" DROP COLUMN "password";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -106,7 +106,6 @@ model Lobby {
   id              Int         @id @default(autoincrement())
   owner_id        Int
   tournament_id   Int
-  password        String
   invite_code     String
   owner           User        @relation(fields: [owner_id], references: [id])
   user_lobbies    UserLobby[]


### PR DESCRIPTION
lobbies table had a password field, but I added an invite code which seems to be more representative of what the intention