### PR TITLE
feat: disable submit prediction button temporarily

### DIFF
--- a/src/components/PredictionForm.tsx
+++ b/src/components/PredictionForm.tsx
@@ -94,6 +94,7 @@ const PredictionForm = ({ game, userId }: Props) => {
         isLoading={submitting}
         type="submit"
         onClick={handleSubmit}
+        disabled
       >
         Save
       </Button>


### PR DESCRIPTION
as part of a test, lets disable while champions league stage continues