### PR TITLE
feat: avoid waiting for all predictions to be processed

### DIFF
--- a/src/pages/api/process-scores.ts
+++ b/src/pages/api/process-scores.ts
@@ -62,18 +62,20 @@ export default async function handler(
       }
     })
 
-    for (const processedPrediction of processedPredictions) {
+    processedPredictions.forEach(async (prediction) => {
       await prisma.prediction.update({
         where: {
-          id: processedPrediction.id,
+          id: prediction.id,
         },
         data: {
-          score: processedPrediction.score,
-          processed: processedPrediction.processed,
+          score: prediction.score,
+          processed: prediction.processed,
         },
       })
-    }
+    })
 
-    res.status(200).json({ message: "Predictions have been processed!" })
+    res.status(200).json({
+      message: `Processing ${processedPredictions.length} predictions`,
+    })
   }
 }


### PR DESCRIPTION
Processing predictions is taking longer than the default time limit on api routes... so lets try not to wait for predictions to be processed and see what happens *shrugs*