### PR TITLE
feat: only process predictions for completed games

### DIFF
--- a/src/pages/api/process-scores.ts
+++ b/src/pages/api/process-scores.ts
@@ -44,23 +44,27 @@ export default async function handler(
       },
     })
 
-    const processedPredictions = unprocessedPredictions.map((prediction) => {
-      const game = games.find((g) => g.id === prediction.game_id)
-      if (!game.completed) return prediction
+    const processedPredictions = unprocessedPredictions.reduce(
+      (result, prediction) => {
+        const game = games.find((g) => g.id === prediction.game_id)
+        if (!game.completed) return result
 
-      let finalScore = 0
-      if (isPerfectScore(game, prediction)) {
-        finalScore = 3
-      } else if (isWinnerMatch(game, prediction)) {
-        finalScore = 1
-      }
+        let finalScore = 0
+        if (isPerfectScore(game, prediction)) {
+          finalScore = 3
+        } else if (isWinnerMatch(game, prediction)) {
+          finalScore = 1
+        }
 
-      return {
-        ...prediction,
-        score: finalScore,
-        processed: true,
-      }
-    })
+        result.push({
+          ...prediction,
+          score: finalScore,
+          processed: true,
+        })
+        return result
+      },
+      []
+    )
 
     processedPredictions.forEach(async (prediction) => {
       await prisma.prediction.update({

--- a/src/pages/tournament/[id]/games.tsx
+++ b/src/pages/tournament/[id]/games.tsx
@@ -66,9 +66,10 @@ const GameAdminPage = () => {
     HTMLButtonElement
   > = async () => {
     setProcessingGames(true)
+    const completedGames = games.filter((g) => g.completed)
     const response = await fetch("/api/process-scores", {
       method: "POST",
-      body: JSON.stringify({ games }),
+      body: JSON.stringify({ games: completedGames }),
     })
     await response.json()
     setProcessingGames(false)


### PR DESCRIPTION
we were previously trying to UPDATE predictions for games that had not been completed, which took too long. Let's change that.